### PR TITLE
Expose FileSystemWatcher.Filters Property

### DIFF
--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -32,9 +32,25 @@ public class FileSystemWatcherEx : IDisposable
 
 
     /// <summary>
+    /// The collection of all the filters used to determine what files are monitored in a directory.
+    /// </summary>
+    public System.Collections.ObjectModel.Collection<string> Filters { get; } = new();
+
+
+    /// <summary>
     /// Filter string used for determining what files are monitored in a directory
     /// </summary>
-    public string Filter { get; set; } = "*.*";
+    public string Filter { 
+        get
+        {
+            return Filters.Count == 0 ? "*" : Filters[0];
+        } 
+        set
+        {
+            Filters.Clear();
+            Filters.Add(value);
+        } 
+    }
 
 
     /// <summary>
@@ -213,7 +229,12 @@ public class FileSystemWatcherEx : IDisposable
         _watcher = new FileWatcher();
 
         _fsw = _watcher.Create(FolderPath, onEvent, onError);
-        _fsw.Filter = Filter;
+
+        foreach(var filter in Filters)
+        {
+            _fsw.Filters.Add(filter);
+        }
+
         _fsw.NotifyFilter = NotifyFilter;
         _fsw.IncludeSubdirectories = IncludeSubdirectories;
         _fsw.SynchronizingObject = SynchronizingObject;

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -40,16 +40,17 @@ public class FileSystemWatcherEx : IDisposable
     /// <summary>
     /// Filter string used for determining what files are monitored in a directory
     /// </summary>
-    public string Filter { 
+    public string Filter
+    {
         get
         {
             return Filters.Count == 0 ? "*" : Filters[0];
-        } 
+        }
         set
         {
             Filters.Clear();
             Filters.Add(value);
-        } 
+        }
     }
 
 
@@ -230,7 +231,7 @@ public class FileSystemWatcherEx : IDisposable
 
         _fsw = _watcher.Create(FolderPath, onEvent, onError);
 
-        foreach(var filter in Filters)
+        foreach (var filter in Filters)
         {
             _fsw.Filters.Add(filter);
         }
@@ -281,7 +282,7 @@ public class FileSystemWatcherEx : IDisposable
         // stop the thread
         _cancelSource.Cancel();
     }
-    
+
 
 
     /// <summary>


### PR DESCRIPTION
Introduced in dotnet core 3.0, FileSystemWatcher has a property which allows multiple filters to exist on a single instance. https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher.filters?view=net-6.0