### PR TITLE
Address code violations

### DIFF
--- a/Source/Demo/Form1.Designer.cs
+++ b/Source/Demo/Form1.Designer.cs
@@ -63,7 +63,7 @@
             this.btnSelectFolder.TabIndex = 1;
             this.btnSelectFolder.Text = "Select folder";
             this.btnSelectFolder.UseVisualStyleBackColor = true;
-            this.btnSelectFolder.Click += new System.EventHandler(this.btnSelectFolder_Click);
+            this.btnSelectFolder.Click += new System.EventHandler(this.BtnSelectFolder_Click);
             // 
             // txtPath
             // 
@@ -85,7 +85,7 @@
             this.btnStart.TabIndex = 3;
             this.btnStart.Text = "Start";
             this.btnStart.UseVisualStyleBackColor = true;
-            this.btnStart.Click += new System.EventHandler(this.btnStart_Click);
+            this.btnStart.Click += new System.EventHandler(this.BtnStart_Click);
             // 
             // btnStop
             // 
@@ -97,7 +97,7 @@
             this.btnStop.TabIndex = 4;
             this.btnStop.Text = "Stop";
             this.btnStop.UseVisualStyleBackColor = true;
-            this.btnStop.Click += new System.EventHandler(this.btnStop_Click);
+            this.btnStop.Click += new System.EventHandler(this.BtnStop_Click);
             // 
             // Form1
             // 

--- a/Source/Demo/Form1.cs
+++ b/Source/Demo/Form1.cs
@@ -14,7 +14,7 @@ namespace Demo
 
 
 
-        private void btnStart_Click(object sender, EventArgs e)
+        private void BtnStart_Click(object sender, EventArgs e)
         {
             _fw = new FileSystemWatcherEx(txtPath.Text.Trim());
 
@@ -34,7 +34,7 @@ namespace Demo
             btnStop.Enabled = true;
         }
 
-        private void FW_OnError(object sender, ErrorEventArgs e)
+        private void FW_OnError(object? sender, ErrorEventArgs e)
         {
             if (txtConsole.InvokeRequired)
             {
@@ -46,28 +46,28 @@ namespace Demo
             }
         }
 
-        private void FW_OnChanged(object sender, FileChangedEvent e)
+        private void FW_OnChanged(object? sender, FileChangedEvent e)
         {
             txtConsole.Text += string.Format("[cha] {0} | {1}",
                 Enum.GetName(typeof(ChangeType), e.ChangeType),
                 e.FullPath) + "\r\n";
         }
 
-        private void FW_OnDeleted(object sender, FileChangedEvent e)
+        private void FW_OnDeleted(object? sender, FileChangedEvent e)
         {
             txtConsole.Text += string.Format("[del] {0} | {1}",
                 Enum.GetName(typeof(ChangeType), e.ChangeType),
                 e.FullPath) + "\r\n";
         }
 
-        private void FW_OnCreated(object sender, FileChangedEvent e)
+        private void FW_OnCreated(object? sender, FileChangedEvent e)
         {
             txtConsole.Text += string.Format("[cre] {0} | {1}",
                 Enum.GetName(typeof(ChangeType), e.ChangeType),
                 e.FullPath) + "\r\n";
         }
 
-        private void FW_OnRenamed(object sender, FileChangedEvent e)
+        private void FW_OnRenamed(object? sender, FileChangedEvent e)
         {
             txtConsole.Text += string.Format("[ren] {0} | {1} ----> {2}",
                 Enum.GetName(typeof(ChangeType), e.ChangeType),
@@ -77,7 +77,7 @@ namespace Demo
 
 
 
-        private void btnStop_Click(object sender, EventArgs e)
+        private void BtnStop_Click(object sender, EventArgs e)
         {
             _fw.Stop();
 
@@ -88,7 +88,7 @@ namespace Demo
         }
 
 
-        private void btnSelectFolder_Click(object sender, EventArgs e)
+        private void BtnSelectFolder_Click(object sender, EventArgs e)
         {
             var fb = new FolderBrowserDialog();
 

--- a/Source/FileWatcherEx/FileEvents.cs
+++ b/Source/FileWatcherEx/FileEvents.cs
@@ -25,7 +25,7 @@ public class FileChangedEvent
     /// <summary>
     /// The old full path (used if ChangeType = RENAMED)
     /// </summary>
-    public string OldFullPath { get; set; } = "";
+    public string? OldFullPath { get; set; } = "";
 }
 
 

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -9,15 +9,15 @@ public class FileSystemWatcherEx : IDisposable
 
     #region Private Properties
 
-    private Thread _thread;
-    private EventProcessor _processor;
-    private BlockingCollection<FileChangedEvent> _fileEventQueue = new();
+    private Thread? _thread;
+    private EventProcessor? _processor;
+    private readonly BlockingCollection<FileChangedEvent> _fileEventQueue = new();
 
     private FileWatcher _watcher = new();
     private FileSystemWatcher _fsw = new();
 
     // Define the cancellation token.
-    private CancellationTokenSource _cancelSource = new();
+    private readonly CancellationTokenSource _cancelSource = new();
 
     #endregion
 
@@ -52,27 +52,27 @@ public class FileSystemWatcherEx : IDisposable
     /// <summary>
     /// Gets or sets the object used to marshal the event handler calls issued as a result of a directory change.
     /// </summary>
-    public ISynchronizeInvoke SynchronizingObject { get; set; }
+    public ISynchronizeInvoke? SynchronizingObject { get; set; }
 
     #endregion
 
 
 
     #region Public Events
-    public delegate void DelegateOnChanged(object sender, FileChangedEvent e);
-    public event DelegateOnChanged OnChanged;
+    public delegate void DelegateOnChanged(object? sender, FileChangedEvent e);
+    public event DelegateOnChanged? OnChanged;
 
-    public delegate void DelegateOnDeleted(object sender, FileChangedEvent e);
-    public event DelegateOnDeleted OnDeleted;
+    public delegate void DelegateOnDeleted(object? sender, FileChangedEvent e);
+    public event DelegateOnDeleted? OnDeleted;
 
-    public delegate void DelegateOnCreated(object sender, FileChangedEvent e);
-    public event DelegateOnCreated OnCreated;
+    public delegate void DelegateOnCreated(object? sender, FileChangedEvent e);
+    public event DelegateOnCreated? OnCreated;
 
-    public delegate void DelegateOnRenamed(object sender, FileChangedEvent e);
-    public event DelegateOnRenamed OnRenamed;
+    public delegate void DelegateOnRenamed(object? sender, FileChangedEvent e);
+    public event DelegateOnRenamed? OnRenamed;
 
-    public delegate void DelegateOnError(object sender, ErrorEventArgs e);
-    public event DelegateOnError OnError;
+    public delegate void DelegateOnError(object? sender, ErrorEventArgs e);
+    public event DelegateOnError? OnError;
     #endregion
 
 
@@ -103,7 +103,7 @@ public class FileSystemWatcherEx : IDisposable
 
                     InvokeChangedEvent(SynchronizingObject, e);
 
-                    void InvokeChangedEvent(object sender, FileChangedEvent fileEvent)
+                    void InvokeChangedEvent(object? sender, FileChangedEvent fileEvent)
                     {
                         if (SynchronizingObject != null && SynchronizingObject.InvokeRequired)
                         {
@@ -122,7 +122,7 @@ public class FileSystemWatcherEx : IDisposable
 
                     InvokeCreatedEvent(SynchronizingObject, e);
 
-                    void InvokeCreatedEvent(object sender, FileChangedEvent fileEvent)
+                    void InvokeCreatedEvent(object? sender, FileChangedEvent fileEvent)
                     {
                         if (SynchronizingObject != null && SynchronizingObject.InvokeRequired)
                         {
@@ -141,7 +141,7 @@ public class FileSystemWatcherEx : IDisposable
 
                     InvokeDeletedEvent(SynchronizingObject, e);
 
-                    void InvokeDeletedEvent(object sender, FileChangedEvent fileEvent)
+                    void InvokeDeletedEvent(object? sender, FileChangedEvent fileEvent)
                     {
                         if (SynchronizingObject != null && SynchronizingObject.InvokeRequired)
                         {
@@ -160,7 +160,7 @@ public class FileSystemWatcherEx : IDisposable
 
                     InvokeRenamedEvent(SynchronizingObject, e);
 
-                    void InvokeRenamedEvent(object sender, FileChangedEvent fileEvent)
+                    void InvokeRenamedEvent(object? sender, FileChangedEvent fileEvent)
                     {
                         if (SynchronizingObject != null && SynchronizingObject.InvokeRequired)
                         {
@@ -232,7 +232,7 @@ public class FileSystemWatcherEx : IDisposable
             try
             {
                 var e = _fileEventQueue.Take(cancelToken);
-                _processor.ProcessEvent(e);
+                _processor?.ProcessEvent(e);
             }
             catch (OperationCanceledException)
             {
@@ -260,7 +260,7 @@ public class FileSystemWatcherEx : IDisposable
         // stop the thread
         _cancelSource.Cancel();
     }
-    
+
 
 
     /// <summary>
@@ -271,6 +271,7 @@ public class FileSystemWatcherEx : IDisposable
         if (_fsw != null)
         {
             _fsw.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -4,6 +4,10 @@ using System.ComponentModel;
 
 namespace FileWatcherEx;
 
+/// <summary>
+/// A wrapper of <see cref="FileSystemWatcher"/> to standardize the events
+/// and avoid false change notifications.
+/// </summary>
 public class FileSystemWatcherEx : IDisposable
 {
 
@@ -26,26 +30,23 @@ public class FileSystemWatcherEx : IDisposable
     #region Public Properties
 
     /// <summary>
-    /// Folder path to watch
+    /// Gets or sets the path of the directory to watch.
     /// </summary>
     public string FolderPath { get; set; } = "";
 
 
     /// <summary>
-    /// The collection of all the filters used to determine what files are monitored in a directory.
+    /// Gets the collection of all the filters used to determine what files are monitored in a directory.
     /// </summary>
     public System.Collections.ObjectModel.Collection<string> Filters { get; } = new();
 
 
     /// <summary>
-    /// Filter string used for determining what files are monitored in a directory
+    /// Gets or sets the filter string used to determine what files are monitored in a directory.
     /// </summary>
     public string Filter
     {
-        get
-        {
-            return Filters.Count == 0 ? "*" : Filters[0];
-        }
+        get => Filters.Count == 0 ? "*" : Filters[0];
         set
         {
             Filters.Clear();
@@ -55,7 +56,11 @@ public class FileSystemWatcherEx : IDisposable
 
 
     /// <summary>
-    /// Gets, sets the type of changes to watch for
+    /// Gets or sets the type of changes to watch for.
+    /// The default is the bitwise OR combination of
+    /// <see cref="NotifyFilters.LastWrite"/>,
+    /// <see cref="NotifyFilters.FileName"/>,
+    /// and <see cref="NotifyFilters.DirectoryName"/>.
     /// </summary>
     public NotifyFilters NotifyFilter { get; set; } = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName;
 
@@ -76,31 +81,57 @@ public class FileSystemWatcherEx : IDisposable
 
 
     #region Public Events
-    public delegate void DelegateOnChanged(object? sender, FileChangedEvent e);
+
+    /// <summary>
+    /// Occurs when a file or directory in the specified
+    /// <see cref="FolderPath"/> is changed.
+    /// </summary>
     public event DelegateOnChanged? OnChanged;
+    public delegate void DelegateOnChanged(object? sender, FileChangedEvent e);
 
-    public delegate void DelegateOnDeleted(object? sender, FileChangedEvent e);
+
+    /// <summary>
+    /// Occurs when a file or directory in the specified
+    /// <see cref="FolderPath"/> is deleted.
+    /// </summary>
     public event DelegateOnDeleted? OnDeleted;
+    public delegate void DelegateOnDeleted(object? sender, FileChangedEvent e);
 
-    public delegate void DelegateOnCreated(object? sender, FileChangedEvent e);
+
+    /// <summary>
+    /// Occurs when a file or directory in the specified
+    /// <see cref="FolderPath"/> is created.
+    /// </summary>
     public event DelegateOnCreated? OnCreated;
+    public delegate void DelegateOnCreated(object? sender, FileChangedEvent e);
 
-    public delegate void DelegateOnRenamed(object? sender, FileChangedEvent e);
+
+    /// <summary>
+    /// Occurs when a file or directory in the specified
+    /// <see cref="FolderPath"/> is renamed.
+    /// </summary>
     public event DelegateOnRenamed? OnRenamed;
+    public delegate void DelegateOnRenamed(object? sender, FileChangedEvent e);
 
-    public delegate void DelegateOnError(object? sender, ErrorEventArgs e);
+
+    /// <summary>
+    /// Occurs when the instance of <see cref="FileSystemWatcherEx"/> is unable to continue
+    /// monitoring changes or when the internal buffer overflows.
+    /// </summary>
     public event DelegateOnError? OnError;
+    public delegate void DelegateOnError(object? sender, ErrorEventArgs e);
+
     #endregion
 
 
 
     /// <summary>
-    /// Initialize new instance of FileWatcherEx
+    /// Initialize new instance of <see cref="FileSystemWatcherEx"/>
     /// </summary>
-    /// <param name="folder"></param>
-    public FileSystemWatcherEx(string folder = "")
+    /// <param name="folderPath"></param>
+    public FileSystemWatcherEx(string folderPath = "")
     {
-        FolderPath = folder;
+        FolderPath = folderPath;
     }
 
 
@@ -244,25 +275,6 @@ public class FileSystemWatcherEx : IDisposable
         _fsw.EnableRaisingEvents = true;
     }
 
-    private void Thread_DoingWork(CancellationToken cancelToken)
-    {
-        while (true)
-        {
-            if (cancelToken.IsCancellationRequested)
-                return;
-
-            try
-            {
-                var e = _fileEventQueue.Take(cancelToken);
-                _processor?.ProcessEvent(e);
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-        }
-    }
-
 
     /// <summary>
     /// Stop watching files
@@ -284,7 +296,6 @@ public class FileSystemWatcherEx : IDisposable
     }
 
 
-
     /// <summary>
     /// Dispose the FileWatcherEx instance
     /// </summary>
@@ -296,5 +307,27 @@ public class FileSystemWatcherEx : IDisposable
             GC.SuppressFinalize(this);
         }
     }
+
+
+
+    private void Thread_DoingWork(CancellationToken cancelToken)
+    {
+        while (true)
+        {
+            if (cancelToken.IsCancellationRequested)
+                return;
+
+            try
+            {
+                var e = _fileEventQueue.Take(cancelToken);
+                _processor?.ProcessEvent(e);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
 
 }

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -13,8 +13,8 @@ public class FileSystemWatcherEx : IDisposable
     private EventProcessor? _processor;
     private readonly BlockingCollection<FileChangedEvent> _fileEventQueue = new();
 
-    private FileWatcher _watcher = new();
-    private FileSystemWatcher _fsw = new();
+    private FileWatcher? _watcher;
+    private FileSystemWatcher? _fsw;
 
     // Define the cancellation token.
     private readonly CancellationTokenSource _cancelSource = new();

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -9,7 +9,7 @@ internal class FileWatcher : IDisposable
 {
     private string _watchPath = string.Empty;
     private Action<FileChangedEvent>? _eventCallback = null;
-    private Dictionary<string, FileSystemWatcher> _fwDictionary = new();
+    private readonly Dictionary<string, FileSystemWatcher> _fwDictionary = new();
     private Action<ErrorEventArgs>? _onError = null;
 
 


### PR DESCRIPTION
- ran `dotnet format severity --info` which set fields to readonly when appropriate and fixes spacing
- made methods that did not access instanced variables static
- since this was moved to net6.0 with nullable enabled, fields that were nullable have been properly declared as nullable
- addressed naming rule violations in Demo
- addressed CA1816 violation by calling `GC.SuppressFinalize(this);` in FileSystemWatcherEx.Dispose()
- made _watcher and _fsw nullable so that we don't have to assign objects to them, they get created on Start() anyway

Really only the last point has any performance ramifications, and that's going to be negligible at best, so this PR is mostly just to satisfy the compiler and get rid of all of the warnings, up to you if you want to merge it of course