### PR TITLE
Create new CancellationTokenSource on Start()

### DIFF
--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -302,6 +302,7 @@ public class FileSystemWatcherEx : IDisposable
     public void Dispose()
     {
         _fsw?.Dispose();
+        _watcher?.Dispose();
         _cancelSource?.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -21,7 +21,7 @@ public class FileSystemWatcherEx : IDisposable
     private FileSystemWatcher? _fsw;
 
     // Define the cancellation token.
-    private readonly CancellationTokenSource _cancelSource = new();
+    private CancellationTokenSource? _cancelSource;
 
     #endregion
 
@@ -231,6 +231,7 @@ public class FileSystemWatcherEx : IDisposable
             Console.WriteLine(string.Format("{0} | {1}", Enum.GetName(typeof(ChangeType), ChangeType.LOG), log));
         });
 
+        _cancelSource = new();
         _thread = new Thread(() => Thread_DoingWork(_cancelSource.Token))
         {
             // this ensures the thread does not block the process from terminating!

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -285,12 +285,10 @@ public class FileSystemWatcherEx : IDisposable
         if (_fsw != null)
         {
             _fsw.EnableRaisingEvents = false;
+            _fsw.Dispose();
         }
 
-        if (_watcher != null)
-        {
-            _watcher.Dispose();
-        }
+        _watcher?.Dispose();
 
         // stop the thread
         _cancelSource?.Cancel();

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -293,7 +293,8 @@ public class FileSystemWatcherEx : IDisposable
         }
 
         // stop the thread
-        _cancelSource.Cancel();
+        _cancelSource?.Cancel();
+        _cancelSource?.Dispose();
     }
 
 
@@ -305,6 +306,7 @@ public class FileSystemWatcherEx : IDisposable
         if (_fsw != null)
         {
             _fsw.Dispose();
+            _cancelSource?.Dispose();
             GC.SuppressFinalize(this);
         }
     }

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -303,12 +303,9 @@ public class FileSystemWatcherEx : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_fsw != null)
-        {
-            _fsw.Dispose();
-            _cancelSource?.Dispose();
-            GC.SuppressFinalize(this);
-        }
+        _fsw?.Dispose();
+        _cancelSource?.Dispose();
+        GC.SuppressFinalize(this);
     }
 
 


### PR DESCRIPTION
As _cancelSource.Cancel() is ran on Stop(), running Start() again will use the already cancelled token and thus the watcher will not function. Pushing the creation of the CancellationTokenSource to Start() solves this.