### PR TITLE
Feature/extract event normalizer

### DIFF
--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -1,6 +1,7 @@
 ﻿
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using FileWatcherEx.Helpers;
 
 namespace FileWatcherEx;
 

--- a/Source/FileWatcherEx/Helpers/EventNormalizer.cs
+++ b/Source/FileWatcherEx/Helpers/EventNormalizer.cs
@@ -125,9 +125,12 @@ internal class EventNormalizer
     }
 
 
-    internal static bool IsParent(string p, string candidate)
+    internal static bool IsParent(string path, string candidatePath)
     {
-        return p.IndexOf(candidate + '\\', StringComparison.Ordinal) == 0;
+        // if exists, remove trailing "\" for both paths
+        candidatePath = candidatePath.TrimEnd('\\'); 
+        path = path.TrimEnd('\\');
+        return path.IndexOf(candidatePath + '\\', StringComparison.Ordinal) == 0;
     }
 
 

--- a/Source/FileWatcherEx/Helpers/EventNormalizer.cs
+++ b/Source/FileWatcherEx/Helpers/EventNormalizer.cs
@@ -1,0 +1,169 @@
+﻿using static FileWatcherEx.ChangeType;
+
+namespace FileWatcherEx.Helpers;
+
+/// <summary>
+/// Tries to fix the real life oddities of the underlying FileSystemWatcher class.
+/// The code here got refactored from the original Microsoft sources.
+/// For real scenario, see  EventNormalizerTest.cs
+/// </summary>
+internal class EventNormalizer
+{
+    private readonly FileEventRepository _eventRepo = new();
+
+    internal IEnumerable<FileChangedEvent> Normalize(FileChangedEvent[] events)
+    {
+        NormalizeDuplicates(events);
+        return FilterDeleted(_eventRepo.Events());
+    }
+
+    private void NormalizeDuplicates(FileChangedEvent[] events)
+    {
+        foreach (var newEvent in events)
+        {
+            var oldEvent = _eventRepo.Find(newEvent.FullPath);
+            // original file event from which we renamed, only applicable for RENAMED event
+            var renameFromEvent = newEvent.ChangeType == RENAMED
+                ? _eventRepo.Find(newEvent.OldFullPath)
+                : null;
+
+            switch (newEvent.ChangeType)
+            {
+                // CREATED followed by CHANGED => CREATED
+                case CHANGED when oldEvent?.ChangeType == CREATED:
+                    // Do nothing
+                    break;
+
+                // CREATED followed by DELETED => remove
+                case DELETED when oldEvent?.ChangeType == CREATED:
+                    _eventRepo.Remove(oldEvent);
+                    break;
+
+                // DELETED followed by CREATED => CHANGED
+                case CREATED when oldEvent?.ChangeType == DELETED:
+                    oldEvent.ChangeType = CHANGED;
+                    break;
+
+                // Scenario:
+                // - file foo is created
+                // - file bar is deleted
+                // - now foo is renamed to the just deleted bar
+                // - this results into a bar changed event
+                case RENAMED when oldEvent?.ChangeType == DELETED && renameFromEvent?.ChangeType == CREATED:
+                    newEvent.ChangeType = CHANGED;
+                    newEvent.OldFullPath = null;
+                    _eventRepo.AddOrUpdate(newEvent);
+
+                    // Remove data about the CREATED file 
+                    _eventRepo.Remove(renameFromEvent);
+                    break;
+
+                // rename from CREATED file, all other cases
+                case RENAMED when renameFromEvent?.ChangeType == CREATED:
+                    newEvent.ChangeType = CREATED;
+                    newEvent.OldFullPath = null;
+                    _eventRepo.AddOrUpdate(newEvent);
+
+                    // Remove data about the CREATED file 
+                    _eventRepo.Remove(renameFromEvent);
+                    break;
+
+                case RENAMED when renameFromEvent?.ChangeType == RENAMED:
+                    newEvent.OldFullPath = renameFromEvent.OldFullPath;
+                    _eventRepo.AddOrUpdate(newEvent);
+
+                    // Remove data about the RENAMED file 
+                    _eventRepo.Remove(renameFromEvent);
+                    break;
+
+                // the LOG event is not coming from the filesystem, hence it is ignored.
+                // ideally, LOG would disappear completely but unfortunately it is part of the public API of this lib
+                case LOG:
+                    // ignore
+                    break;
+
+                default:
+                    _eventRepo.AddOrUpdate(newEvent);
+                    break;
+            }
+        }
+    }
+
+    // This algorithm will remove all DELETE events up to the root folder
+    // that got deleted if any. This ensures that we are not producing
+    // DELETE events for each file inside a folder that gets deleted.
+    //
+    // 1.) split ADD/CHANGE and DELETED events
+    // 2.) sort short deleted paths to the top
+    // 3.) for each DELETE, check if there is a deleted parent and ignore the event in that case
+    internal static IEnumerable<FileChangedEvent> FilterDeleted(IEnumerable<FileChangedEvent> eventsWithoutDuplicates)
+    {
+        // Handle deletes
+        var deletedPaths = new List<string>();
+        return eventsWithoutDuplicates
+            .Select((e, n) => new KeyValuePair<int, FileChangedEvent>(n, e)) // store original position value
+            .OrderBy(e => e.Value.FullPath.Length) // shortest path first
+            .Where(e => IsParent(e.Value, deletedPaths))
+            .OrderBy(e => e.Key) // restore original position
+            .Select(e => e.Value);
+    }
+
+    internal static bool IsParent(FileChangedEvent e, List<string> deletedPaths)
+    {
+        if (e.ChangeType == DELETED)
+        {
+            if (deletedPaths.Any(d => IsParent(e.FullPath, d)))
+            {
+                return false; // DELETE is ignored if parent is deleted already
+            }
+
+            // otherwise mark as deleted
+            deletedPaths.Add(e.FullPath);
+        }
+
+        return true;
+    }
+
+
+    internal static bool IsParent(string p, string candidate)
+    {
+        return p.IndexOf(candidate + '\\', StringComparison.Ordinal) == 0;
+    }
+
+
+    private class FileEventRepository
+    {
+        private readonly Dictionary<string, FileChangedEvent> _mapPathToEvents = new();
+
+        public void AddOrUpdate(FileChangedEvent newEvent)
+        {
+            if (_mapPathToEvents.TryGetValue(newEvent.FullPath, out var oldEvent))
+            {
+                // update existing
+                oldEvent.ChangeType = newEvent.ChangeType;
+                oldEvent.OldFullPath = newEvent.OldFullPath;
+            }
+            else
+            {
+                // add
+                _mapPathToEvents[newEvent.FullPath] = newEvent;
+            }
+        }
+
+        public void Remove(FileChangedEvent ev)
+        {
+            _mapPathToEvents.Remove(ev.FullPath);
+        }
+
+        public FileChangedEvent? Find(string? path)
+        {
+            _mapPathToEvents.TryGetValue(path ?? "", out var oldEvent);
+            return oldEvent;
+        }
+
+        public List<FileChangedEvent> Events()
+        {
+            return _mapPathToEvents.Values.ToList();
+        }
+    }
+}

--- a/Source/FileWatcherEx/Helpers/EventProcessor.cs
+++ b/Source/FileWatcherEx/Helpers/EventProcessor.cs
@@ -2,8 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-using static FileWatcherEx.ChangeType;
-
 namespace FileWatcherEx.Helpers;
 
 internal class EventProcessor
@@ -32,150 +30,6 @@ internal class EventProcessor
     private long _spamCheckStartTime = 0;
     private bool _spamWarningLogged = false;
     
-    internal static IEnumerable<FileChangedEvent> NormalizeEvents(FileChangedEvent[] events)
-    {
-        var eventRepo = new FileEventRepository();
-
-        // Normalize duplicates
-        foreach (var newEvent in events)
-        {
-            var oldEvent = eventRepo.Find(newEvent.FullPath);
-            // original file event from which we renamed
-            var renameFromEvent = newEvent.ChangeType == RENAMED 
-                ? eventRepo.Find(newEvent.OldFullPath) 
-                : null;
-
-            switch (newEvent.ChangeType)
-            {
-                // CREATED followed by DELETED => remove
-                case DELETED when oldEvent?.ChangeType == CREATED:
-                    eventRepo.Remove(oldEvent);
-                    break;
-
-                // DELETED followed by CREATED => CHANGED
-                case CREATED when oldEvent?.ChangeType == DELETED:
-                    oldEvent.ChangeType = CHANGED;
-                    break;
-
-                // CREATED followed by CHANGED => CREATED
-                case CHANGED when oldEvent?.ChangeType == CREATED:
-                    // Do nothing
-                    break;
-
-                // rename from CREATED file
-                case RENAMED when renameFromEvent?.ChangeType == CREATED:
-                    // Remove data about the CREATED file 
-                    eventRepo.Remove(renameFromEvent);
-                    // Handle new event as CREATED
-                    newEvent.ChangeType = CREATED;
-                    newEvent.OldFullPath = null;
-
-                    if (oldEvent?.ChangeType == DELETED)
-                    {
-                        // DELETED followed by CREATED => CHANGED
-                        newEvent.ChangeType = CHANGED;
-                    }
-
-                    eventRepo.AddOrUpdate(newEvent);
-                    break;
-
-                case RENAMED when renameFromEvent?.ChangeType == RENAMED:
-                    newEvent.OldFullPath = renameFromEvent.OldFullPath;
-                    // Remove data about the RENAMED file 
-                    eventRepo.Remove(renameFromEvent);
-                    eventRepo.AddOrUpdate(newEvent);
-                    break;
-
-                // TODO why does "LOG" need to be in the filewevent ?
-                case LOG:
-
-                default:
-                    eventRepo.AddOrUpdate(newEvent);
-                    break;
-            }
-        }
-
-        return FilterDeleted(eventRepo.Events());
-    }
-
-    private class FileEventRepository
-    {
-        private readonly Dictionary<string, FileChangedEvent> _mapPathToEvents = new();
-
-        public void AddOrUpdate(FileChangedEvent newEvent)
-        {
-            if (_mapPathToEvents.TryGetValue(newEvent.FullPath, out var oldEvent))
-            {
-                // update existing
-                oldEvent.ChangeType = newEvent.ChangeType;
-                oldEvent.OldFullPath = newEvent.OldFullPath;
-            }
-            else
-            {
-                // add
-                _mapPathToEvents[newEvent.FullPath] = newEvent;
-            }
-        }
-
-        public void Remove(FileChangedEvent ev)
-        {
-            _mapPathToEvents.Remove(ev.FullPath);
-        }
-
-        public FileChangedEvent? Find(string? path)
-        {
-            _mapPathToEvents.TryGetValue(path ?? "", out var oldEvent);
-            return oldEvent;
-        }
-
-        public List<FileChangedEvent> Events()
-        {
-            return _mapPathToEvents.Values.ToList();
-        }
-    }
-
-    // This algorithm will remove all DELETE events up to the root folder
-    // that got deleted if any. This ensures that we are not producing
-    // DELETE events for each file inside a folder that gets deleted.
-    //
-    // 1.) split ADD/CHANGE and DELETED events
-    // 2.) sort short deleted paths to the top
-    // 3.) for each DELETE, check if there is a deleted parent and ignore the event in that case
-    internal static IEnumerable<FileChangedEvent> FilterDeleted(IEnumerable<FileChangedEvent> eventsWithoutDuplicates)
-    {
-        // Handle deletes
-        var deletedPaths = new List<string>();
-        return eventsWithoutDuplicates
-            .Select((e, n) => new KeyValuePair<int, FileChangedEvent>(n, e)) // store original position value
-            .OrderBy(e => e.Value.FullPath.Length) // shortest path first
-            .Where(e => IsParent(e.Value, deletedPaths))
-            .OrderBy(e => e.Key) // restore original position
-            .Select(e => e.Value);
-    }
-
-    internal static bool IsParent(FileChangedEvent e, List<string> deletedPaths)
-    {
-        if (e.ChangeType == DELETED)
-        {
-            if (deletedPaths.Any(d => IsParent(e.FullPath, d)))
-            {
-                return false; // DELETE is ignored if parent is deleted already
-            }
-
-            // otherwise mark as deleted
-            deletedPaths.Add(e.FullPath);
-        }
-
-        return true;
-    }
-
-
-    internal static bool IsParent(string p, string candidate)
-    {
-        return p.IndexOf(candidate + '\\', StringComparison.Ordinal) == 0;
-    }
-
-
     public EventProcessor(Action<FileChangedEvent> onEvent, Action<string> onLogging)
     {
         _handleEvent = onEvent;
@@ -219,7 +73,7 @@ internal class EventProcessor
                         if (_delayStarted == _lastEventTime)
                         {
                             // Normalize and handle
-                            var normalized = NormalizeEvents(_events.ToArray());
+                            var normalized = new EventNormalizer().Normalize(_events.ToArray());
                             foreach (var e in normalized)
                             {
                                 _handleEvent(e);

--- a/Source/FileWatcherEx/Helpers/EventProcessor.cs
+++ b/Source/FileWatcherEx/Helpers/EventProcessor.cs
@@ -41,35 +41,41 @@ internal class EventProcessor
         // Normalize duplicates
         foreach (var newEvent in events)
         {
-            mapPathToEvents.TryGetValue(newEvent.FullPath, out FileChangedEvent? oldEvent); // Try get event from newEvent.FullPath
+            mapPathToEvents.TryGetValue(newEvent.FullPath,
+                out FileChangedEvent? oldEvent); // Try get event from newEvent.FullPath
 
             if (oldEvent?.ChangeType == CREATED && newEvent.ChangeType == DELETED)
-            { // CREATED + DELETED => remove
+            {
+                // CREATED + DELETED => remove
                 mapPathToEvents.Remove(oldEvent.FullPath);
                 eventsWithoutDuplicates.Remove(oldEvent);
             }
-            else
-            if (oldEvent?.ChangeType == DELETED && newEvent.ChangeType == CREATED)
-            { // DELETED + CREATED => CHANGED
+            else if (oldEvent?.ChangeType == DELETED && newEvent.ChangeType == CREATED)
+            {
+                // DELETED + CREATED => CHANGED
                 oldEvent.ChangeType = CHANGED;
             }
-            else
-            if (oldEvent?.ChangeType == CREATED && newEvent.ChangeType == CHANGED)
-            { // CREATED + CHANGED => CREATED
-              // Do nothing
+            else if (oldEvent?.ChangeType == CREATED && newEvent.ChangeType == CHANGED)
+            {
+                // CREATED + CHANGED => CREATED
+                // Do nothing
             }
             else
-            { // Otherwise
+            {
+                // Otherwise
 
                 if (newEvent.ChangeType == RENAMED)
-                { // If <ANY> + RENAMED
+                {
+                    // If <ANY> + RENAMED
                     do
                     {
-                        mapPathToEvents.TryGetValue(newEvent.OldFullPath!, out var renameFromEvent); // Try get event from newEvent.OldFullPath
+                        mapPathToEvents.TryGetValue(newEvent.OldFullPath!,
+                            out var renameFromEvent); // Try get event from newEvent.OldFullPath
 
                         if (renameFromEvent != null && renameFromEvent.ChangeType == CREATED)
-                        { // If rename from CREATED file
-                          // Remove data about the CREATED file 
+                        {
+                            // If rename from CREATED file
+                            // Remove data about the CREATED file 
                             mapPathToEvents.Remove(renameFromEvent.FullPath);
                             eventsWithoutDuplicates.Remove(renameFromEvent);
                             // Handle new event as CREATED
@@ -77,14 +83,15 @@ internal class EventProcessor
                             newEvent.OldFullPath = null;
 
                             if (oldEvent?.ChangeType == DELETED)
-                            { // DELETED + CREATED => CHANGED
+                            {
+                                // DELETED + CREATED => CHANGED
                                 newEvent.ChangeType = CHANGED;
                             }
                         }
-                        else
-                        if (renameFromEvent != null && renameFromEvent.ChangeType == RENAMED)
-                        { // If rename from RENAMED file
-                          // Remove data about the RENAMED file 
+                        else if (renameFromEvent != null && renameFromEvent.ChangeType == RENAMED)
+                        {
+                            // If rename from RENAMED file
+                            // Remove data about the RENAMED file 
                             mapPathToEvents.Remove(renameFromEvent.FullPath);
                             eventsWithoutDuplicates.Remove(renameFromEvent);
                             // Change OldFullPath
@@ -93,30 +100,33 @@ internal class EventProcessor
                             continue;
                         }
                         else
-                        { // Otherwise
-                          // Do nothing
-                          //mapPathToEvents.TryGetValue(newEvent.OldFullPath, out oldEvent); // Try get event from newEvent.OldFullPath
+                        {
+                            // Otherwise
+                            // Do nothing
+                            //mapPathToEvents.TryGetValue(newEvent.OldFullPath, out oldEvent); // Try get event from newEvent.OldFullPath
                         }
                     } while (false);
                 }
 
                 if (oldEvent != null)
-                { // If old event exists
-                  // Replace old event data with data from the new event
+                {
+                    // If old event exists
+                    // Replace old event data with data from the new event
                     oldEvent.ChangeType = newEvent.ChangeType;
                     oldEvent.OldFullPath = newEvent.OldFullPath;
                 }
                 else
-                { // If old event is not exist
-                  // Add new event
+                {
+                    // If old event is not exist
+                    // Add new event
                     mapPathToEvents.Add(newEvent.FullPath, newEvent);
                     eventsWithoutDuplicates.Add(newEvent);
                 }
             }
         }
-        
 
-        return FilterDeleted(eventsWithoutDuplicates); 
+
+        return FilterDeleted(eventsWithoutDuplicates);
     }
 
     // This algorithm will remove all DELETE events up to the root folder
@@ -159,7 +169,7 @@ internal class EventProcessor
     {
         return p.IndexOf(candidate + '\\', StringComparison.Ordinal) == 0;
     }
-    
+
 
     public EventProcessor(Action<FileChangedEvent> onEvent, Action<string> onLogging)
     {
@@ -183,7 +193,9 @@ internal class EventProcessor
             else if (!_spamWarningLogged && _spamCheckStartTime + EventSpamWarningThreshold < now)
             {
                 _spamWarningLogged = true;
-                _logger(string.Format("Warning: Watcher is busy catching up with {0} file changes in 60 seconds. Latest path is '{1}'", _events.Count, fileEvent.FullPath));
+                _logger(string.Format(
+                    "Warning: Watcher is busy catching up with {0} file changes in 60 seconds. Latest path is '{1}'",
+                    _events.Count, fileEvent.FullPath));
             }
 
             // Add into our queue
@@ -229,7 +241,4 @@ internal class EventProcessor
             }
         }
     }
-
-
 }
-

--- a/Source/FileWatcherExTests/EventNormalizerTest.cs
+++ b/Source/FileWatcherExTests/EventNormalizerTest.cs
@@ -164,7 +164,31 @@ public class EventNormalizerTest
         Assert.Empty(events);
     }
 
+    [Fact]
+    public void Created_Event_After_Deleted_Results_Into_Changed()
+    {
+        var events = NormalizeEvents(
+            new FileChangedEvent
+            {
+                ChangeType = ChangeType.DELETED,
+                FullPath = @"c:\foo",
+                OldFullPath = null
+            },
+            new FileChangedEvent
+            {
+                ChangeType = ChangeType.CREATED,
+                FullPath = @"c:\foo",
+                OldFullPath = null
+            }
+        );
 
+        Assert.Single(events);
+        var ev = events.First();
+        Assert.Equal(ChangeType.CHANGED, ev.ChangeType);
+        Assert.Equal(@"c:\foo", ev.FullPath);
+        Assert.Null(ev.OldFullPath);
+    }
+    
     [Fact]
     public void Changed_Event_After_Created_Is_Ignored()
     {

--- a/Source/FileWatcherExTests/EventNormalizerTest.cs
+++ b/Source/FileWatcherExTests/EventNormalizerTest.cs
@@ -4,7 +4,7 @@ using FileWatcherEx.Helpers;
 
 namespace FileWatcherExTests;
 
-public class EventProcessorTest
+public class EventNormalizerTest
 {
     [Fact]
     public void No_Input_Gives_No_Output()
@@ -215,7 +215,7 @@ public class EventProcessorTest
             }
         };
 
-        var filtered = EventProcessor.FilterDeleted(events);
+        var filtered = EventNormalizer.FilterDeleted(events);
         Assert.Equal(events, filtered);
     }
 
@@ -244,7 +244,7 @@ public class EventProcessorTest
             }
         };
 
-        var filtered = EventProcessor.FilterDeleted(events).ToList();
+        var filtered = EventNormalizer.FilterDeleted(events).ToList();
         Assert.Equal(2, filtered.Count);
         Assert.Equal(ChangeType.DELETED, filtered[0].ChangeType);
         Assert.Equal(@"c:\bar", filtered[0].FullPath);
@@ -255,15 +255,15 @@ public class EventProcessorTest
     [Fact]
     public void Is_Parent()
     {
-        Assert.True(EventProcessor.IsParent(@"c:\a\b", @"c:"));
-        Assert.True(EventProcessor.IsParent(@"c:\a\b", @"c:\a"));
+        Assert.True(EventNormalizer.IsParent(@"c:\a\b", @"c:"));
+        Assert.True(EventNormalizer.IsParent(@"c:\a\b", @"c:\a"));
 
         // candidate must not have backslash
-        Assert.False(EventProcessor.IsParent(@"c:\a\b", @"c:\"));
-        Assert.False(EventProcessor.IsParent(@"c:\a\b", @"c:\a\"));
+        Assert.False(EventNormalizer.IsParent(@"c:\a\b", @"c:\"));
+        Assert.False(EventNormalizer.IsParent(@"c:\a\b", @"c:\a\"));
         
-        Assert.False(EventProcessor.IsParent(@"c:\", @"c:\foo"));
-        Assert.False(EventProcessor.IsParent(@"c:\", @"c:\"));
+        Assert.False(EventNormalizer.IsParent(@"c:\", @"c:\foo"));
+        Assert.False(EventNormalizer.IsParent(@"c:\", @"c:\"));
     }
 
     [Fact]
@@ -275,7 +275,7 @@ public class EventProcessorTest
             FullPath = @"c:\foo"
         };
 
-        Assert.True(EventProcessor.IsParent(ev, new List<string>()));
+        Assert.True(EventNormalizer.IsParent(ev, new List<string>()));
     }
     
     [Fact]
@@ -289,7 +289,7 @@ public class EventProcessorTest
             FullPath = @"c:\foo"
         };
         
-        Assert.True(EventProcessor.IsParent(parentDirEvent, deletedFiles));
+        Assert.True(EventNormalizer.IsParent(parentDirEvent, deletedFiles));
 
         
         var subDirEvent = new FileChangedEvent
@@ -298,11 +298,11 @@ public class EventProcessorTest
             FullPath = @"c:\foo\bar"
         };
         
-        Assert.False(EventProcessor.IsParent(subDirEvent, deletedFiles));
+        Assert.False(EventNormalizer.IsParent(subDirEvent, deletedFiles));
     }
     
     private static List<FileChangedEvent> NormalizeEvents(params FileChangedEvent[] events)
     {
-        return EventProcessor.NormalizeEvents(events).ToList();
+        return new EventNormalizer().Normalize(events).ToList();
     }
 }

--- a/Source/FileWatcherExTests/EventNormalizerTest.cs
+++ b/Source/FileWatcherExTests/EventNormalizerTest.cs
@@ -143,7 +143,7 @@ public class EventNormalizerTest
         Assert.Null(ev.OldFullPath);
     }
 
-[Fact]
+    [Fact]
     public void Result_Suppressed_If_Delete_After_Create()
     {
         var events = NormalizeEvents(
@@ -163,7 +163,7 @@ public class EventNormalizerTest
 
         Assert.Empty(events);
     }
-    
+
 
     [Fact]
     public void Changed_Event_After_Created_Is_Ignored()
@@ -251,19 +251,19 @@ public class EventNormalizerTest
         Assert.Equal(ChangeType.CREATED, filtered[1].ChangeType);
         Assert.Equal(@"c:\foo", filtered[1].FullPath);
     }
-    
-    [Fact]
-    public void Is_Parent()
-    {
-        Assert.True(EventNormalizer.IsParent(@"c:\a\b", @"c:"));
-        Assert.True(EventNormalizer.IsParent(@"c:\a\b", @"c:\a"));
 
-        // candidate must not have backslash
-        Assert.False(EventNormalizer.IsParent(@"c:\a\b", @"c:\"));
-        Assert.False(EventNormalizer.IsParent(@"c:\a\b", @"c:\a\"));
-        
-        Assert.False(EventNormalizer.IsParent(@"c:\", @"c:\foo"));
-        Assert.False(EventNormalizer.IsParent(@"c:\", @"c:\"));
+    [Theory]
+    [InlineData(@"c:\a\b", @"c:", true)]
+    [InlineData(@"c:\a\b", @"c:\a", true)]
+    [InlineData(@"c:\a\b\", @"c:", true)]
+    [InlineData(@"c:\a\b\", @"c:\a", true)]
+    [InlineData(@"c:\a\b", @"c:\", true)]
+    [InlineData(@"c:\a\b", @"c:\a\", true)]
+    [InlineData(@"c:\", @"c:\foo", false)]
+    [InlineData(@"c:\", @"c:\", false)]
+    public void Is_Parent(string path, string candidatePath, bool expectedResult)
+    {
+        Assert.Equal(expectedResult, EventNormalizer.IsParent(path, candidatePath));
     }
 
     [Fact]
@@ -277,30 +277,30 @@ public class EventNormalizerTest
 
         Assert.True(EventNormalizer.IsParent(ev, new List<string>()));
     }
-    
+
     [Fact]
     public void Delete_Event_For_Subdirectory_Is_Detected()
     {
         var deletedFiles = new List<string>();
-        
+
         var parentDirEvent = new FileChangedEvent
         {
             ChangeType = ChangeType.DELETED,
             FullPath = @"c:\foo"
         };
-        
+
         Assert.True(EventNormalizer.IsParent(parentDirEvent, deletedFiles));
 
-        
+
         var subDirEvent = new FileChangedEvent
         {
             ChangeType = ChangeType.DELETED,
             FullPath = @"c:\foo\bar"
         };
-        
+
         Assert.False(EventNormalizer.IsParent(subDirEvent, deletedFiles));
     }
-    
+
     private static List<FileChangedEvent> NormalizeEvents(params FileChangedEvent[] events)
     {
         return new EventNormalizer().Normalize(events).ToList();

--- a/Source/FileWatcherExTests/EventProcessorTest.cs
+++ b/Source/FileWatcherExTests/EventProcessorTest.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using FileWatcherEx;
+using FileWatcherEx.Helpers;
 
 namespace FileWatcherExTests;
 


### PR DESCRIPTION
First Refactoring PR

Focus was on EventProcessor/ NormalizeEvents as this is the main de-duplication logic.
Some IDE fixes/ renaming suggestions were applied to more conform to C# conventions. 

The major part was to extract NormalizeEvents functionality into a separate `EventNormalizer` class. Idea was to have a large switch statement listing all the special cases for which there are workarounds/ modifications of the received events.

As usual, feel free to comment or apply changes yourself.

