### PR TITLE
Feature/refactor file watcher

### DIFF
--- a/Source/Demo/Form1.Designer.cs
+++ b/Source/Demo/Form1.Designer.cs
@@ -74,7 +74,7 @@
             this.txtPath.Name = "txtPath";
             this.txtPath.Size = new System.Drawing.Size(508, 57);
             this.txtPath.TabIndex = 2;
-            this.txtPath.Text = "C:\\Users\\d2pha\\Desktop\\New folder";
+            this.txtPath.Text = "C:\\";
             // 
             // btnStart
             // 

--- a/Source/Demo/Form1.cs
+++ b/Source/Demo/Form1.cs
@@ -108,15 +108,7 @@ namespace Demo
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
-            try
-            {
-                _fw.Stop();
-                _fw.Dispose();
-            }
-            catch
-            {
-                // intentionally empty
-            }
+            _fw.Dispose();
         }
     }
 }

--- a/Source/Demo/Form1.cs
+++ b/Source/Demo/Form1.cs
@@ -16,7 +16,7 @@ namespace Demo
 
         private void BtnStart_Click(object sender, EventArgs e)
         {
-            _fw = new FileSystemWatcherEx(txtPath.Text.Trim());
+            _fw = new FileSystemWatcherEx(txtPath.Text.Trim(), FW_OnLog);
 
             _fw.OnRenamed += FW_OnRenamed;
             _fw.OnCreated += FW_OnCreated;
@@ -76,8 +76,11 @@ namespace Demo
                 e.FullPath) + "\r\n";
         }
 
-
-
+        private void FW_OnLog(string value)
+        {
+            txtConsole.Text += $@"[log] {value}" + "\r\n";;
+        }
+        
         private void BtnStop_Click(object sender, EventArgs e)
         {
             _fw.Stop();
@@ -105,8 +108,15 @@ namespace Demo
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
-            _fw.Stop();
-            _fw.Dispose();
+            try
+            {
+                _fw.Stop();
+                _fw.Dispose();
+            }
+            catch
+            {
+                // intentionally empty
+            }
         }
     }
 }

--- a/Source/Demo/Form1.cs
+++ b/Source/Demo/Form1.cs
@@ -26,7 +26,7 @@ namespace Demo
 
             _fw.SynchronizingObject = this;
             _fw.IncludeSubdirectories = true;
-            
+
             _fw.Start();
 
             btnStart.Enabled = false;
@@ -78,9 +78,9 @@ namespace Demo
 
         private void FW_OnLog(string value)
         {
-            txtConsole.Text += $@"[log] {value}" + "\r\n";;
+            txtConsole.Text += $@"[log] {value}" + "\r\n";
         }
-        
+
         private void BtnStop_Click(object sender, EventArgs e)
         {
             _fw.Stop();

--- a/Source/Demo/README.md
+++ b/Source/Demo/README.md
@@ -1,0 +1,9 @@
+﻿Manual Testing
+--------------
+
+This little application is helpful for interactive testing of the library. 
+
+Symlinks
+--------
+To create a symlink directory on Windows, use `mklink`.
+Example: `mklink /D my-symbolic-link c:\temp\target-directory`

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -269,18 +269,18 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         // - `watcher` should delegate the set properties to ALL file watchers
         // - if you register a dir later, these 4 properties should be used
         // Start watcher
-        _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, _ => {});
-        _fsw = _watcher.Init();
-
-        foreach (var filter in Filters)
+        // _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, _ => {});
+        
+        // TODO do some manual testing
+        _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, Console.WriteLine)
         {
-            _fsw.Filters.Add(filter);
-        }
-
-        _fsw.NotifyFilter = NotifyFilter;
-        _fsw.IncludeSubdirectories = IncludeSubdirectories;
-        _fsw.SynchronizingObject = SynchronizingObject;
-        _fsw.EnableRaisingEvents = true;
+            NotifyFilter = NotifyFilter,
+            IncludeSubdirectories = IncludeSubdirectories,
+            SynchronizingObject = SynchronizingObject,
+            EnableRaisingEvents = true
+        };
+        Filters.ToList().ForEach(filter => _watcher.Filters.Add(filter));
+        _watcher.Init();
     }
 
     internal void StartForTesting(

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -20,6 +20,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
     private FileWatcher? _watcher;
     private IFileSystemWatcherWrapper? _fsw;
     private Func<IFileSystemWatcherWrapper>? _fswFactory;
+    private readonly Action<string> _logger;
 
     // Define the cancellation token.
     private CancellationTokenSource? _cancelSource;
@@ -134,12 +135,13 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
     /// Initialize new instance of <see cref="FileSystemWatcherEx"/>
     /// </summary>
     /// <param name="folderPath"></param>
-    public FileSystemWatcherEx(string folderPath = "")
+    /// <param name="logger">Optional Action to log out library internals</param>
+    public FileSystemWatcherEx(string folderPath = "", Action<string>? logger = null)
     {
         FolderPath = folderPath;
+        _logger = logger ?? (_ => {}) ;
     }
-
-
+    
     /// <summary>
     /// Start watching files
     /// </summary>
@@ -262,17 +264,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
             }
         }
 
-
-        // TODO
-        // - FileWatcher should not return underlying filewatcher 
-        // - introduce stronger encapsulation
-        // - `watcher` should delegate the set properties to ALL file watchers
-        // - if you register a dir later, these 4 properties should be used
-        // Start watcher
-        // _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, _ => {});
-        
-        // TODO do some manual testing
-        _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, Console.WriteLine)
+        _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, _logger)
         {
             NotifyFilter = NotifyFilter,
             IncludeSubdirectories = IncludeSubdirectories,
@@ -344,6 +336,5 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
             }
         }
     }
-
-
 }
+

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -271,7 +271,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         // Start watcher
         _watcher = new FileWatcher();
 
-        _fsw = _watcher.Create(FolderPath, onEvent, onError, FileSystemWatcherFactory);
+        _fsw = _watcher.Create(FolderPath, onEvent, onError, FileSystemWatcherFactory, _ => {});
 
         foreach (var filter in Filters)
         {

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -86,6 +86,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
 
     #endregion
 
+
     #region Public Events
 
     /// <summary>
@@ -141,6 +142,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         _logger = logger ?? (_ => {}) ;
     }
     
+
     /// <summary>
     /// Start watching files
     /// </summary>
@@ -273,6 +275,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         _watcher.Init();
     }
 
+
     internal void StartForTesting(
         Func<string, FileAttributes> getFileAttributesFunc, 
         Func<string, DirectoryInfo[]> getDirectoryInfosFunc)
@@ -306,7 +309,6 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         _cancelSource?.Dispose();
         GC.SuppressFinalize(this);
     }
-
 
 
     private void Thread_DoingWork(CancellationToken cancelToken)

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -278,16 +278,11 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
             _fsw.Filters.Add(filter);
         }
 
-        // all
         _fsw.NotifyFilter = NotifyFilter;
         // all. if this is not enabled, then also no additional file watchers should be registered
         _fsw.IncludeSubdirectories = IncludeSubdirectories;
         
-        // exception: only root watcher
         _fsw.SynchronizingObject = SynchronizingObject;
-
-        // global
-        // Start watching
         _fsw.EnableRaisingEvents = true;
     }
 

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -263,6 +263,11 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         }
 
 
+        // TODO
+        // - FileWatcher should not return underlying filewatcher 
+        // - introduce stronger encapsulation
+        // - `watcher` should delegate the set properties to ALL file watchers
+        // - if you register a dir later, these 4 properties should be used
         // Start watcher
         _watcher = new FileWatcher();
 

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -269,19 +269,24 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         // - `watcher` should delegate the set properties to ALL file watchers
         // - if you register a dir later, these 4 properties should be used
         // Start watcher
-        _watcher = new FileWatcher();
+        _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, _ => {});
+        _fsw = _watcher.Init();
 
-        _fsw = _watcher.Create(FolderPath, onEvent, onError, FileSystemWatcherFactory, _ => {});
-
+        // all
         foreach (var filter in Filters)
         {
             _fsw.Filters.Add(filter);
         }
 
+        // all
         _fsw.NotifyFilter = NotifyFilter;
+        // all. if this is not enabled, then also no additional file watchers should be registered
         _fsw.IncludeSubdirectories = IncludeSubdirectories;
+        
+        // exception: only root watcher
         _fsw.SynchronizingObject = SynchronizingObject;
 
+        // global
         // Start watching
         _fsw.EnableRaisingEvents = true;
     }

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -17,7 +17,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
     private EventProcessor? _processor;
     private readonly BlockingCollection<FileChangedEvent> _fileEventQueue = new();
 
-    private FileWatcher? _watcher;
+    private SymlinkAwareFileWatcher? _watcher;
     private Func<IFileSystemWatcherWrapper>? _fswFactory;
     private readonly Action<string> _logger;
 
@@ -262,7 +262,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
             }
         }
 
-        _watcher = new FileWatcher(FolderPath, OnEvent, OnError, FileSystemWatcherFactory, _logger)
+        _watcher = new SymlinkAwareFileWatcher(FolderPath, OnEvent, OnError, FileSystemWatcherFactory, _logger)
         {
             NotifyFilter = NotifyFilter,
             IncludeSubdirectories = IncludeSubdirectories,

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -234,10 +234,10 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
             }
         }, (log) =>
         {
-            Console.WriteLine(string.Format("{0} | {1}", Enum.GetName(typeof(ChangeType), ChangeType.LOG), log));
+            Console.WriteLine($"{Enum.GetName(typeof(ChangeType), ChangeType.LOG)} | {log}");
         });
 
-        _cancelSource = new();
+        _cancelSource = new CancellationTokenSource();
         _thread = new Thread(() => Thread_DoingWork(_cancelSource.Token))
         {
             // this ensures the thread does not block the process from terminating!
@@ -248,22 +248,21 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
 
 
         // Log each event in our special format to output queue
-        void onEvent(FileChangedEvent e)
+        void OnEvent(FileChangedEvent e)
         {
             _fileEventQueue.Add(e);
         }
 
 
-        // OnError
-        void onError(ErrorEventArgs e)
+        void OnError(ErrorEventArgs e)
         {
             if (e != null)
             {
-                OnError?.Invoke(this, e);
+                this.OnError?.Invoke(this, e);
             }
         }
 
-        _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, _logger)
+        _watcher = new FileWatcher(FolderPath, OnEvent, OnError, FileSystemWatcherFactory, _logger)
         {
             NotifyFilter = NotifyFilter,
             IncludeSubdirectories = IncludeSubdirectories,

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -272,14 +272,13 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         _watcher = new FileWatcher(FolderPath, onEvent, onError, FileSystemWatcherFactory, _ => {});
         _fsw = _watcher.Init();
 
-        // all
         foreach (var filter in Filters)
         {
             _fsw.Filters.Add(filter);
         }
 
         _fsw.NotifyFilter = NotifyFilter;
-        // all. if this is not enabled, then also no additional file watchers should be registered
+        // TODO all. if this is not enabled, then also no additional file watchers should be registered
         _fsw.IncludeSubdirectories = IncludeSubdirectories;
         
         _fsw.SynchronizingObject = SynchronizingObject;

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -1,6 +1,7 @@
 ﻿
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using FileWatcherEx.Helpers;
 
 namespace FileWatcherEx;
 

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -278,9 +278,7 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
         }
 
         _fsw.NotifyFilter = NotifyFilter;
-        // TODO all. if this is not enabled, then also no additional file watchers should be registered
         _fsw.IncludeSubdirectories = IncludeSubdirectories;
-        
         _fsw.SynchronizingObject = SynchronizingObject;
         _fsw.EnableRaisingEvents = true;
     }

--- a/Source/FileWatcherEx/FileSystemWatcherEx.cs
+++ b/Source/FileWatcherEx/FileSystemWatcherEx.cs
@@ -18,7 +18,6 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
     private readonly BlockingCollection<FileChangedEvent> _fileEventQueue = new();
 
     private FileWatcher? _watcher;
-    private IFileSystemWatcherWrapper? _fsw;
     private Func<IFileSystemWatcherWrapper>? _fswFactory;
     private readonly Action<string> _logger;
 
@@ -291,12 +290,6 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
     /// </summary>
     public void Stop()
     {
-        if (_fsw != null)
-        {
-            _fsw.EnableRaisingEvents = false;
-            _fsw.Dispose();
-        }
-
         _watcher?.Dispose();
 
         // stop the thread
@@ -310,7 +303,6 @@ public class FileSystemWatcherEx : IDisposable, IFileSystemWatcherEx
     /// </summary>
     public void Dispose()
     {
-        _fsw?.Dispose();
         _watcher?.Dispose();
         _cancelSource?.Dispose();
         GC.SuppressFinalize(this);

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -9,7 +9,6 @@ namespace FileWatcherEx.Helpers;
 
 internal class FileWatcher : IDisposable
 {
-    // TODO double check properties -> are they all needed ?
     private readonly string _watchPath;
     private readonly Action<FileChangedEvent>? _eventCallback;
     private readonly Action<ErrorEventArgs>? _onError;
@@ -81,7 +80,6 @@ internal class FileWatcher : IDisposable
     }
 
     // TODO when no sub dirs are watched, also no sym links are watched
-    // TODO build warnings
 
     private void RegisterFileWatcher(string path)
     {
@@ -195,7 +193,7 @@ internal class FileWatcher : IDisposable
     /// <summary>
     /// Cleanup filewatcher if a symbolic link dir is deleted
     /// </summary>
-    internal void UnregisterFileWatcherForSymbolicLinkDir(object sender, FileSystemEventArgs e)
+    internal void UnregisterFileWatcherForSymbolicLinkDir(object? _, FileSystemEventArgs e)
     {
         if (FileWatchers.ContainsKey(e.FullPath))
         {
@@ -224,9 +222,10 @@ internal class FileWatcher : IDisposable
     /// </summary>
     public void Dispose()
     {
-        foreach (var pair in FileWatchers)
+        foreach (var watcher in FileWatchers.Select(pair => pair.Value))
         {
-            pair.Value.Dispose();
+            watcher.EnableRaisingEvents = false;
+            watcher.Dispose();
         }
     }
 }

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-namespace FileWatcherEx;
+namespace FileWatcherEx.Helpers;
 
 internal class FileWatcher : IDisposable
 {

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -44,10 +44,13 @@ internal class FileWatcher : IDisposable
                                                       | NotifyFilters.DirectoryName;
     public bool EnableRaisingEvents { get; set; }
     
+    public bool IncludeSubdirectories { get; set; }
+    
     public Collection<string> Filters { get; } = new();
 
     public ISynchronizeInvoke? SynchronizingObject { get; set; }
-
+    
+    
     /// <summary>
     /// Create new instance of FileSystemWatcherWrapper
     ///
@@ -106,7 +109,7 @@ internal class FileWatcher : IDisposable
     {
         fileWatcher.Path = path;
         fileWatcher.NotifyFilter = NotifyFilter;
-        fileWatcher.IncludeSubdirectories = true;
+        fileWatcher.IncludeSubdirectories = IncludeSubdirectories;
         fileWatcher.EnableRaisingEvents = EnableRaisingEvents;
         Filters.ToList().ForEach(filter => fileWatcher.Filters.Add(filter));
 

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -175,7 +175,7 @@ internal class FileWatcher : IDisposable
     {
         try
         {
-            if (IsSymbolicLinkDirectory(path) && !FileWatchers.ContainsKey(path))
+            if (IsSymbolicLinkDirectory(path) && IncludeSubdirectories && !FileWatchers.ContainsKey(path))
             {
                 _logger($"Directory {path} is a symbolic link dir. Will register additional file watcher.");
                 RegisterFileWatcher(path);

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -74,22 +74,21 @@ internal class FileWatcher : IDisposable
         _onError = onError;
     }
 
-    public IFileSystemWatcherWrapper Init()
+    public void Init()
     {
-        var watcher = RegisterFileWatcher(_watchPath);
+        RegisterFileWatcher(_watchPath);
         RegisterAdditionalFileWatchersForSymLinkDirs(_watchPath);
-        return watcher;
     }
 
 
-    private IFileSystemWatcherWrapper RegisterFileWatcher(string path)
+    private void RegisterFileWatcher(string path)
     {
+        _logger($"Registering file watcher for {path}");
         var fileWatcher = _watcherFactory();
         SetFileWatcherProperties(fileWatcher, path);
         RegisterFileWatcherEventHandlers(fileWatcher);
 
         FileWatchers.Add(path, fileWatcher);
-        return fileWatcher;
     }
 
     private void RegisterFileWatcherEventHandlers(IFileSystemWatcherWrapper fileWatcher)
@@ -178,6 +177,7 @@ internal class FileWatcher : IDisposable
         {
             if (IsSymbolicLinkDirectory(path) && !FileWatchers.ContainsKey(path))
             {
+                _logger($"Directory {path} is a symbolic link dir. Will register additional file watcher.");
                 RegisterFileWatcher(path);
             }
         }

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -55,14 +55,14 @@ internal class FileWatcher : IDisposable
                                | NotifyFilters.DirectoryName;
 
         // Bind internal events to manipulate the possible symbolic links
-        watcher.Created += new(MakeWatcher_Created);
-        watcher.Deleted += new(MakeWatcher_Deleted);
+        watcher.Created += MakeWatcher_Created;
+        watcher.Deleted += MakeWatcher_Deleted;
 
-        watcher.Changed += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CHANGED));
-        watcher.Created += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CREATED));
-        watcher.Deleted += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.DELETED));
-        watcher.Renamed += new((object _, RenamedEventArgs e) => ProcessEvent(e));
-        watcher.Error += new ErrorEventHandler((object source, ErrorEventArgs e) => onError(e));
+        watcher.Changed += (_, e) => ProcessEvent(e, ChangeType.CHANGED);
+        watcher.Created += (_, e) => ProcessEvent(e, ChangeType.CREATED);
+        watcher.Deleted += (_, e) => ProcessEvent(e, ChangeType.DELETED);
+        watcher.Renamed += (_, e) => ProcessEvent(e);
+        watcher.Error += (source, e) => onError(e);
 
         //changing this to a higher value can lead into issues when watching UNC drives
         watcher.InternalBufferSize = 32768;
@@ -136,14 +136,14 @@ internal class FileWatcher : IDisposable
             fileSystemWatcherRoot.EnableRaisingEvents = true;
 
             // Bind internal events to manipulate the possible symbolic links
-            fileSystemWatcherRoot.Created += new(MakeWatcher_Created);
-            fileSystemWatcherRoot.Deleted += new(MakeWatcher_Deleted);
+            fileSystemWatcherRoot.Created += MakeWatcher_Created;
+            fileSystemWatcherRoot.Deleted += MakeWatcher_Deleted;
 
-            fileSystemWatcherRoot.Changed += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CHANGED));
-            fileSystemWatcherRoot.Created += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CREATED));
-            fileSystemWatcherRoot.Deleted += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.DELETED));
-            fileSystemWatcherRoot.Renamed += new((object _, RenamedEventArgs e) => ProcessEvent(e));
-            fileSystemWatcherRoot.Error += new((object _, ErrorEventArgs e) => _onError?.Invoke(e));
+            fileSystemWatcherRoot.Changed += (_, e) => ProcessEvent(e, ChangeType.CHANGED);
+            fileSystemWatcherRoot.Created += (_, e) => ProcessEvent(e, ChangeType.CREATED);
+            fileSystemWatcherRoot.Deleted += (_, e) => ProcessEvent(e, ChangeType.DELETED);
+            fileSystemWatcherRoot.Renamed += (_, e) => ProcessEvent(e);
+            fileSystemWatcherRoot.Error += (_, e) => _onError?.Invoke(e);
 
             _fwDictionary.Add(path, fileSystemWatcherRoot);
         }
@@ -164,14 +164,14 @@ internal class FileWatcher : IDisposable
                     fswItem.EnableRaisingEvents = true;
 
                     // Bind internal events to manipulate the possible symbolic links
-                    fswItem.Created += new(MakeWatcher_Created);
-                    fswItem.Deleted += new(MakeWatcher_Deleted);
+                    fswItem.Created += MakeWatcher_Created;
+                    fswItem.Deleted += MakeWatcher_Deleted;
 
-                    fswItem.Changed += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CHANGED));
-                    fswItem.Created += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CREATED));
-                    fswItem.Deleted += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.DELETED));
-                    fswItem.Renamed += new((object _, RenamedEventArgs e) => ProcessEvent(e));
-                    fswItem.Error += new((object _, ErrorEventArgs e) => _onError?.Invoke(e));
+                    fswItem.Changed += (_, e) => ProcessEvent(e, ChangeType.CHANGED);
+                    fswItem.Created += (_, e) => ProcessEvent(e, ChangeType.CREATED);
+                    fswItem.Deleted += (_, e) => ProcessEvent(e, ChangeType.DELETED);
+                    fswItem.Renamed += (_, e) => ProcessEvent(e);
+                    fswItem.Error += (_, e) => _onError?.Invoke(e);
 
                     _fwDictionary.Add(item.FullName, fswItem);
                 }
@@ -196,14 +196,14 @@ internal class FileWatcher : IDisposable
                 watcherCreated.EnableRaisingEvents = true;
 
                 // Bind internal events to manipulate the possible symbolic links
-                watcherCreated.Created += new(MakeWatcher_Created);
-                watcherCreated.Deleted += new(MakeWatcher_Deleted);
+                watcherCreated.Created += MakeWatcher_Created;
+                watcherCreated.Deleted += MakeWatcher_Deleted;
 
-                watcherCreated.Changed += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CHANGED));
-                watcherCreated.Created += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.CREATED));
-                watcherCreated.Deleted += new((object _, FileSystemEventArgs e) => ProcessEvent(e, ChangeType.DELETED));
-                watcherCreated.Renamed += new((object _, RenamedEventArgs e) => ProcessEvent(e));
-                watcherCreated.Error += new((object _, ErrorEventArgs e) => _onError?.Invoke(e));
+                watcherCreated.Changed += (_, e) => ProcessEvent(e, ChangeType.CHANGED);
+                watcherCreated.Created += (_, e) => ProcessEvent(e, ChangeType.CREATED);
+                watcherCreated.Deleted += (_, e) => ProcessEvent(e, ChangeType.DELETED);
+                watcherCreated.Renamed += (_, e) => ProcessEvent(e);
+                watcherCreated.Error += (_, e) => _onError?.Invoke(e);
 
                 _fwDictionary.Add(e.FullPath, watcherCreated);
             }

--- a/Source/FileWatcherEx/Helpers/FileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/FileWatcher.cs
@@ -42,17 +42,19 @@ internal class FileWatcher : IDisposable
     /// <param name="onError">onError callback</param>
     /// <param name="watcherFactory">how to create a FileSystemWatcher</param>
     /// <param name="logger">logging callback</param>
-    /// <returns></returns>
-    public IFileSystemWatcherWrapper Create(string path, Action<FileChangedEvent> onEvent, Action<ErrorEventArgs> onError, Func<IFileSystemWatcherWrapper> watcherFactory, Action<string> logger)
+    public FileWatcher(string path, Action<FileChangedEvent> onEvent, Action<ErrorEventArgs> onError, Func<IFileSystemWatcherWrapper> watcherFactory, Action<string> logger)
     {
         _logger = logger;
         _watcherFactory = watcherFactory;
         _watchPath = path;
         _eventCallback = onEvent;        
         _onError = onError;
-
+    }
+    
+    public IFileSystemWatcherWrapper Init()
+    {
         var watcher = RegisterFileWatcher(_watchPath, enableRaisingEvents: false);
-        RegisterAdditionalFileWatchersForSymLinkDirs(path);
+        RegisterAdditionalFileWatchersForSymLinkDirs(_watchPath);
         return watcher;
     }
 
@@ -89,7 +91,8 @@ internal class FileWatcher : IDisposable
     
     
     /// <summary>
-    /// Recursively find sym link dir and register them 
+    /// Recursively find sym link dir and register them.
+    /// Background: the native filewatcher does not follow symlinks so they need to be treated separately.
     /// </summary>
     private void RegisterAdditionalFileWatchersForSymLinkDirs(string path)
     {

--- a/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 
 namespace FileWatcherEx.Helpers;
 
-internal class FileWatcher : IDisposable
+internal class SymlinkAwareFileWatcher : IDisposable
 {
     private readonly string _watchPath;
     private readonly Action<FileChangedEvent>? _eventCallback;
@@ -63,7 +63,7 @@ internal class FileWatcher : IDisposable
     /// <param name="onError">onError callback</param>
     /// <param name="watcherFactory">how to create a FileSystemWatcher</param>
     /// <param name="logger">logging callback</param>
-    public FileWatcher(string path, Action<FileChangedEvent> onEvent, Action<ErrorEventArgs> onError,
+    public SymlinkAwareFileWatcher(string path, Action<FileChangedEvent> onEvent, Action<ErrorEventArgs> onError,
         Func<IFileSystemWatcherWrapper> watcherFactory, Action<string> logger)
     {
         _logger = logger;
@@ -78,8 +78,6 @@ internal class FileWatcher : IDisposable
         RegisterFileWatcher(_watchPath);
         RegisterAdditionalFileWatchersForSymLinkDirs(_watchPath);
     }
-
-    // TODO when no sub dirs are watched, also no sym links are watched
 
     private void RegisterFileWatcher(string path)
     {

--- a/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
@@ -66,11 +66,11 @@ internal class SymlinkAwareFileWatcher : IDisposable
     public SymlinkAwareFileWatcher(string path, Action<FileChangedEvent> onEvent, Action<ErrorEventArgs> onError,
         Func<IFileSystemWatcherWrapper> watcherFactory, Action<string> logger)
     {
-        _logger = logger;
-        _watcherFactory = watcherFactory;
         _watchPath = path;
         _eventCallback = onEvent;
         _onError = onError;
+        _watcherFactory = watcherFactory;
+        _logger = logger;
     }
 
     public void Init()
@@ -108,6 +108,12 @@ internal class SymlinkAwareFileWatcher : IDisposable
         fileWatcher.InternalBufferSize = 32768;
     }
 
+        
+    private bool IsRootPath(string path)
+    {
+        return _watchPath == path;
+    }
+
     private void RegisterFileWatcherEventHandlers(IFileSystemWatcherWrapper fileWatcher)
     {
         fileWatcher.Created += (_, e) => ProcessEvent(e, ChangeType.CREATED);
@@ -121,12 +127,6 @@ internal class SymlinkAwareFileWatcher : IDisposable
         fileWatcher.Deleted += UnregisterFileWatcherForSymbolicLinkDir;
     }
     
-    private bool IsRootPath(string path)
-    {
-        return _watchPath == path;
-    }
-
-
     /// <summary>
     /// Recursively find sym link dir and register them.
     /// Background: the native filewatcher does not follow symlinks so they need to be treated separately.

--- a/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
@@ -48,15 +48,16 @@ internal class SymlinkAwareFileWatcher : IDisposable
     public Collection<string> Filters { get; } = new();
 
     public ISynchronizeInvoke? SynchronizingObject { get; set; }
-    
-    
+
+
     /// <summary>
-    /// Create new instance of FileSystemWatcherWrapper
-    ///
+    /// Create new instance of <see cref="FileSystemWatcherWrapper"/>.
     /// Object creation follows this order:
-    /// 1) create new instance
-    /// 2) set properties (optional)
-    /// 3) call init() (mandatory)
+    /// <list type="table">
+    ///   <item>1) create new instance</item>
+    ///   <item>2) set properties (optional)</item>
+    ///   <item>3) call init() (mandatory)</item>
+    /// </list>
     /// </summary>
     /// <param name="path">Full folder path to watcher</param>
     /// <param name="onEvent">onEvent callback</param>

--- a/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
@@ -78,7 +78,7 @@ internal class SymlinkAwareFileWatcher : IDisposable
         RegisterFileWatcher(_watchPath);
         RegisterAdditionalFileWatchersForSymLinkDirs(_watchPath);
     }
-
+    
     private void RegisterFileWatcher(string path)
     {
         _logger($"Registering file watcher for {path}");
@@ -169,6 +169,10 @@ internal class SymlinkAwareFileWatcher : IDisposable
     }
 
 
+    /// <summary>
+    /// Safely register a file watcher for a symbolic link directory. Used at startup as well as callback on file creation.
+    /// </summary>
+    /// <param name="path"></param>
     internal void TryRegisterFileWatcherForSymbolicLinkDir(string path)
     {
         try
@@ -216,7 +220,7 @@ internal class SymlinkAwareFileWatcher : IDisposable
 
 
     /// <summary>
-    /// Dispose the instance
+    /// Stop raising events and Dispose all filewatchers 
     /// </summary>
     public void Dispose()
     {

--- a/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
+++ b/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
@@ -90,7 +90,7 @@ public class FileSystemWatcherCreationTest
         Directory.CreateDirectory(subdirPath);
         
         // simulate file watcher trigger
-        _uut.RegisterWatcherForSymbolicLinkDir(null, 
+        _uut.AddFileWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Created, dir.FullPath, "subdir"));
 
         // subdir is ignored
@@ -102,7 +102,7 @@ public class FileSystemWatcherCreationTest
         Directory.CreateSymbolicLink(symlinkPath, subdirPath);
 
         // simulate file watcher trigger
-        _uut.RegisterWatcherForSymbolicLinkDir(null, 
+        _uut.AddFileWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Created, dir.FullPath, "sym"));
 
         // symlink dir is registered
@@ -114,7 +114,7 @@ public class FileSystemWatcherCreationTest
         Directory.Delete(symlinkPath);
         
         // simulate file watcher trigger
-        _uut.RemoveWatcherForSymbolicLinkDir(null, 
+        _uut.RemoveFileWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Deleted, dir.FullPath, "sym"));
         
         // sym-link file watcher is removed
@@ -127,7 +127,7 @@ public class FileSystemWatcherCreationTest
     [Fact]
     public void MakeWatcher_Create_Exceptions_Are_Silently_Ignored()
     {
-        _uut.RegisterWatcherForSymbolicLinkDir(null, 
+        _uut.AddFileWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Created, "/not/existing", "foo"));
     }
     

--- a/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
+++ b/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
@@ -28,9 +28,10 @@ public class FileSystemWatcherCreationTest
 
         _uut.Create(
             dir.FullPath, 
-            e => {}, 
-            e => {},
-            WatcherFactoryWithMemory);
+            _ => {}, 
+            _ => {},
+            WatcherFactoryWithMemory,
+            _ => {});
             
         AssertContainsWatcherFor(dir.FullPath);
     }
@@ -66,9 +67,10 @@ public class FileSystemWatcherCreationTest
 
         _uut.Create(
             dir.FullPath, 
-            e => {}, 
-            e => {},
-            WatcherFactoryWithMemory);
+            _ => {}, 
+            _ => {},
+            WatcherFactoryWithMemory,
+            _ => {});
         
         AssertContainsWatcherFor(dir.FullPath);
         AssertContainsWatcherFor(symlinkPath1);
@@ -81,17 +83,17 @@ public class FileSystemWatcherCreationTest
         using var dir = new TempDir();
         _uut.Create(
             dir.FullPath, 
-            e => {}, 
-            e => {},
-            WatcherFactoryWithMemory);
+            _ => {}, 
+            _ => {},
+            WatcherFactoryWithMemory,
+            _ => {});
         
         // create subdir
         var subdirPath = Path.Combine(dir.FullPath, "subdir");
         Directory.CreateDirectory(subdirPath);
         
         // simulate file watcher trigger
-        _uut.AddFileWatcherForSymbolicLinkDir(null, 
-            new FileSystemEventArgs(WatcherChangeTypes.Created, dir.FullPath, "subdir"));
+        _uut.TryRegisterFileWatcherForSymbolicLinkDir(subdirPath);
 
         // subdir is ignored
         Assert.Single(_uut.FwDictionary);
@@ -102,8 +104,7 @@ public class FileSystemWatcherCreationTest
         Directory.CreateSymbolicLink(symlinkPath, subdirPath);
 
         // simulate file watcher trigger
-        _uut.AddFileWatcherForSymbolicLinkDir(null, 
-            new FileSystemEventArgs(WatcherChangeTypes.Created, dir.FullPath, "sym"));
+        _uut.TryRegisterFileWatcherForSymbolicLinkDir(symlinkPath);
 
         // symlink dir is registered
         Assert.Equal(2, _uut.FwDictionary.Count);
@@ -114,7 +115,7 @@ public class FileSystemWatcherCreationTest
         Directory.Delete(symlinkPath);
         
         // simulate file watcher trigger
-        _uut.RemoveFileWatcherForSymbolicLinkDir(null, 
+        _uut.UnregisterFileWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Deleted, dir.FullPath, "sym"));
         
         // sym-link file watcher is removed
@@ -127,8 +128,7 @@ public class FileSystemWatcherCreationTest
     [Fact]
     public void MakeWatcher_Create_Exceptions_Are_Silently_Ignored()
     {
-        _uut.AddFileWatcherForSymbolicLinkDir(null, 
-            new FileSystemEventArgs(WatcherChangeTypes.Created, "/not/existing", "foo"));
+        _uut.TryRegisterFileWatcherForSymbolicLinkDir("/not/existing/foo");
     }
     
     private void AssertContainsWatcherFor(string path)

--- a/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
+++ b/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
@@ -1,4 +1,5 @@
 ﻿using FileWatcherEx;
+using FileWatcherEx.Helpers;
 using FileWatcherExTests.Helper;
 using Moq;
 using Xunit;

--- a/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
+++ b/Source/FileWatcherExTests/FileSystemWatcherCreationTest.cs
@@ -90,7 +90,7 @@ public class FileSystemWatcherCreationTest
         Directory.CreateDirectory(subdirPath);
         
         // simulate file watcher trigger
-        _uut.MakeWatcher_Created(null, 
+        _uut.RegisterWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Created, dir.FullPath, "subdir"));
 
         // subdir is ignored
@@ -102,7 +102,7 @@ public class FileSystemWatcherCreationTest
         Directory.CreateSymbolicLink(symlinkPath, subdirPath);
 
         // simulate file watcher trigger
-        _uut.MakeWatcher_Created(null, 
+        _uut.RegisterWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Created, dir.FullPath, "sym"));
 
         // symlink dir is registered
@@ -114,7 +114,7 @@ public class FileSystemWatcherCreationTest
         Directory.Delete(symlinkPath);
         
         // simulate file watcher trigger
-        _uut.MakeWatcher_Deleted(null, 
+        _uut.RemoveWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Deleted, dir.FullPath, "sym"));
         
         // sym-link file watcher is removed
@@ -127,7 +127,7 @@ public class FileSystemWatcherCreationTest
     [Fact]
     public void MakeWatcher_Create_Exceptions_Are_Silently_Ignored()
     {
-        _uut.MakeWatcher_Created(null, 
+        _uut.RegisterWatcherForSymbolicLinkDir(null, 
             new FileSystemEventArgs(WatcherChangeTypes.Created, "/not/existing", "foo"));
     }
     

--- a/Source/FileWatcherExTests/FileWatcherExTests.csproj
+++ b/Source/FileWatcherExTests/FileWatcherExTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/Source/FileWatcherExTests/FileWatcherTest.cs
+++ b/Source/FileWatcherExTests/FileWatcherTest.cs
@@ -200,7 +200,7 @@ public class FileWatcherTest
 
     private void AssertContainsWatcherFor(string path)
     {
-        var _ = _uut.FileWatchers[path];
+        var _ = _uut?.FileWatchers[path];
         var foundMocks = (
                 from mock in _mocks
                 where HasPropertySetTo(mock, watcher => watcher.Path = path)

--- a/Source/FileWatcherExTests/FileWatcherTest.cs
+++ b/Source/FileWatcherExTests/FileWatcherTest.cs
@@ -133,6 +133,7 @@ public class FileWatcherTest
         _uut.Filters.Add("*.foo");
         _uut.Filters.Add("*.bar");
         _uut.EnableRaisingEvents = true;
+        _uut.IncludeSubdirectories = true;
         var syncObj = new Mock<ISynchronizeInvoke>().Object;
         _uut.SynchronizingObject = syncObj;
 
@@ -158,6 +159,10 @@ public class FileWatcherTest
             _mocks,
             mock =>
                 mock.VerifySet(w => w.EnableRaisingEvents = true));
+        Assert.All(
+            _mocks,
+            mock =>
+                mock.VerifySet(w => w.IncludeSubdirectories = true));
         Assert.All(
             _mocks, 
             mock => Assert.Equal(mock.Object.Filters, new Collection<string> { "*.foo", "*.bar" }));

--- a/Source/FileWatcherExTests/FileWatcherTest.cs
+++ b/Source/FileWatcherExTests/FileWatcherTest.cs
@@ -41,20 +41,16 @@ public class FileWatcherTest
         using var dir = new TempDir();
 
         // {tempdir}/subdir1
-        var subdirPath1 = Path.Combine(dir.FullPath, "subdir1");
-        Directory.CreateDirectory(subdirPath1);
+        var subdirPath1 = dir.CreateSubDir("subdir1");
 
         // {tempdir}/subdir2
-        var subdirPath2 = Path.Combine(dir.FullPath, "subdir2");
-        Directory.CreateDirectory(subdirPath2);
+        var subdirPath2 = dir.CreateSubDir("subdir2");
 
         // symlink {tempdir}/sym1 to {tempdir}/subdir1
-        var symlinkPath1 = Path.Combine(dir.FullPath, "sym1");
-        Directory.CreateSymbolicLink(symlinkPath1, subdirPath1);
+        var symlinkPath1 = dir.CreateSymlink(symLink: "sym1", target: subdirPath1);
 
         // symlink {tempdir}/sym1/sym2 to {tempdir}/subdir2
-        var symlinkPath2 = Path.Combine(dir.FullPath, "sym1", "sym2");
-        Directory.CreateSymbolicLink(symlinkPath2, subdirPath2);
+        var symlinkPath2 = dir.CreateSymlink(symLink: new []{"sym1", "sym2"}, target: subdirPath2);
 
         _uut = CreateFileWatcher(dir.FullPath);
 
@@ -69,9 +65,7 @@ public class FileWatcherTest
         using var dir = new TempDir();
         _uut = CreateFileWatcher(dir.FullPath);
 
-        // create subdir
-        var subdirPath = Path.Combine(dir.FullPath, "subdir");
-        Directory.CreateDirectory(subdirPath);
+        var subdirPath = dir.CreateSubDir("subdir");
 
         // simulate file watcher trigger
         _uut.TryRegisterFileWatcherForSymbolicLinkDir(subdirPath);
@@ -80,9 +74,7 @@ public class FileWatcherTest
         Assert.Single(_uut.FwDictionary);
         AssertContainsWatcherFor(dir.FullPath);
 
-        // create symlink
-        var symlinkPath = Path.Combine(dir.FullPath, "sym");
-        Directory.CreateSymbolicLink(symlinkPath, subdirPath);
+        var symlinkPath = dir.CreateSymlink(symLink: "sym", target: subdirPath);
 
         // simulate file watcher trigger
         _uut.TryRegisterFileWatcherForSymbolicLinkDir(symlinkPath);

--- a/Source/FileWatcherExTests/Helper/TempDir.cs
+++ b/Source/FileWatcherExTests/Helper/TempDir.cs
@@ -10,6 +10,21 @@ public class TempDir : IDisposable
         Directory.CreateDirectory(FullPath);
     }
 
+    public string CreateSubDir(string path)
+    {
+        var subDirPath = Path.Combine(FullPath, path);
+        Directory.CreateDirectory(subDirPath);
+        return subDirPath;
+    }
+    
+    public string CreateSymlink(string target, params string[] symLink)
+    {
+        var allElements = new[] { FullPath }.Concat(symLink).ToArray();
+        var symlinkPath = Path.Combine(allElements);
+        Directory.CreateSymbolicLink(symlinkPath, target);
+        return symlinkPath;
+    }
+
     public void Dispose()
     {
         Directory.Delete(FullPath, true);

--- a/Source/FileWatcherExTests/ReplayFileSystemWatcherWrapper.cs
+++ b/Source/FileWatcherExTests/ReplayFileSystemWatcherWrapper.cs
@@ -72,7 +72,7 @@ public class ReplayFileSystemWatcherWrapper : IFileSystemWatcherWrapper
     public event FileSystemEventHandler? Changed;
     public event RenamedEventHandler? Renamed;
 
-    // unused in replay implementation
+    #pragma warning disable CS8618 // unused in replay implementation
     public string Path { get; set; }
 
     public Collection<string> Filters => _filters;
@@ -80,6 +80,8 @@ public class ReplayFileSystemWatcherWrapper : IFileSystemWatcherWrapper
     public bool IncludeSubdirectories { get; set; }
     public bool EnableRaisingEvents { get; set; }
     public NotifyFilters NotifyFilter { get; set; }
+
+    #pragma warning disable CS0067 // unused in replay implementation
     public event ErrorEventHandler? Error;
     public int InternalBufferSize { get; set; }
     public ISynchronizeInvoke? SynchronizingObject { get; set; }

--- a/Source/FileWatcherExTests/SymlinkAwareFileWatcherTest.cs
+++ b/Source/FileWatcherExTests/SymlinkAwareFileWatcherTest.cs
@@ -253,5 +253,4 @@ public class SymlinkAwareFileWatcherTest
             return false;
         }
     }
-
 }

--- a/Source/FileWatcherExTests/SymlinkAwareFileWatcherTest.cs
+++ b/Source/FileWatcherExTests/SymlinkAwareFileWatcherTest.cs
@@ -3,21 +3,20 @@ using System.ComponentModel;
 using FileWatcherEx;
 using FileWatcherEx.Helpers;
 using FileWatcherExTests.Helper;
-using Microsoft.VisualBasic;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FileWatcherExTests;
 
-public class FileWatcherTest
+public class SymlinkAwareFileWatcherTest
 {
     private readonly ITestOutputHelper _testOutputHelper;
     // TODO can this be on a test level
-    private FileWatcher? _uut;
+    private SymlinkAwareFileWatcher? _uut;
     private readonly List<Mock<IFileSystemWatcherWrapper>> _mocks;
 
-    public FileWatcherTest(ITestOutputHelper testOutputHelper)
+    public SymlinkAwareFileWatcherTest(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
         _mocks = new List<Mock<IFileSystemWatcherWrapper>>();
@@ -121,7 +120,7 @@ public class FileWatcherTest
             symLink: "sym1",
             target: subDir); 
 
-        _uut = new FileWatcher(dir.FullPath,
+        _uut = new SymlinkAwareFileWatcher(dir.FullPath,
             _ => { },
             _ => { },
             WatcherFactoryWithMemory,
@@ -191,7 +190,7 @@ public class FileWatcherTest
             symLink: "sym1",
             target: subDir); 
 
-        _uut = new FileWatcher(dir.FullPath,
+        _uut = new SymlinkAwareFileWatcher(dir.FullPath,
             _ => { },
             _ => { },
             WatcherFactoryWithMemory,
@@ -213,9 +212,9 @@ public class FileWatcherTest
     }
 
     
-    private FileWatcher CreateFileWatcher(string path)
+    private SymlinkAwareFileWatcher CreateFileWatcher(string path)
     {
-        var fw = new FileWatcher(path,
+        var fw = new SymlinkAwareFileWatcher(path,
             _ => { },
             _ => { },
             WatcherFactoryWithMemory,


### PR DESCRIPTION
3rd + last + largest refactoring

Focus was on the former `FileWatcher` (now `SymlinkAwareFileWatcher`) class which mainly deals with registering one root file watcher and optional filewatchers for symlink directories.

# Change overview

## SymlinkAwareFileWatcher
- rename `FileWatcher` to `SymlinkAwareFileWatcher`
- `SymlinkAwareFileWatcher` encapsulates all registered filewatchers
- properties of `SymlinkAwareFileWatcher` are internally propagated to all registered filewatchers including the symlink ones. This wasn't the case in the old code. There, only the root watcher received the external config. The symlink watchers were using defaults.
- rewrite symlink watcher registration logic. Backed by existing tests so we should be good

## Demo application
- output logging
- fix: no GUI error on closing (just calling `_fw.Dispose()` is enough)

## Various
- `FileSystemWatcherEx` constructor takes an optional Action<string> for logging
- various IDE proposed renaming/ syntax improvements

# Open/ unclear:
In `Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs` > `SetFileWatcherProperties` the `SynchronizingObject` is only registered for the root watcher (old behavior). So for symlink dirs there is no chance to provide a `SynchronizingObject` via the FileSystemWatcherEx API. This is the old behavior, however, I am unsure if this is intended. 
