### PR TITLE
fix IncludeSubdirectories check

### DIFF
--- a/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
@@ -136,12 +136,14 @@ internal class SymlinkAwareFileWatcher : IDisposable
     {
         TryRegisterFileWatcherForSymbolicLinkDir(path);
 
-        if (Directory.Exists(path))
+        if (!IncludeSubdirectories || !Directory.Exists(path))
         {
-            foreach (var dirInfo in GetDirectoryInfosFunc(path))
-            {
-                RegisterAdditionalFileWatchersForSymLinkDirs(dirInfo.FullName);
-            }
+            return;
+        }
+        
+        foreach (var dirInfo in GetDirectoryInfosFunc(path))
+        {
+            RegisterAdditionalFileWatchersForSymLinkDirs(dirInfo.FullName);
         }
     }
 
@@ -178,7 +180,7 @@ internal class SymlinkAwareFileWatcher : IDisposable
     {
         try
         {
-            if (IsSymbolicLinkDirectory(path) && IncludeSubdirectories && !FileWatchers.ContainsKey(path))
+            if (IsSymbolicLinkDirectory(path) && !FileWatchers.ContainsKey(path))
             {
                 _logger($"Directory {path} is a symbolic link dir. Will register additional file watcher.");
                 RegisterFileWatcher(path);


### PR DESCRIPTION
IncludeSubdirectories was being checked after searching for all subdirectories, for each subdirectory found.

Let's check before checking for subdirectories instead

Partially fixes #15 but does not fix cases where monitoring subdirectories might fail in cases where there are cyclical symlinks