### PR TITLE
fix tests

### DIFF
--- a/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
@@ -180,7 +180,7 @@ internal class SymlinkAwareFileWatcher : IDisposable
     {
         try
         {
-            if (IsSymbolicLinkDirectory(path) && IncludeSubdirectories && Include!FileWatchers.ContainsKey(path))
+            if (IsSymbolicLinkDirectory(path) && IncludeSubdirectories && !FileWatchers.ContainsKey(path))
             {
                 _logger($"Directory {path} is a symbolic link dir. Will register additional file watcher.");
                 RegisterFileWatcher(path);

--- a/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
+++ b/Source/FileWatcherEx/Helpers/SymlinkAwareFileWatcher.cs
@@ -180,7 +180,7 @@ internal class SymlinkAwareFileWatcher : IDisposable
     {
         try
         {
-            if (IsSymbolicLinkDirectory(path) && !FileWatchers.ContainsKey(path))
+            if (IsSymbolicLinkDirectory(path) && IncludeSubdirectories && Include!FileWatchers.ContainsKey(path))
             {
                 _logger($"Directory {path} is a symbolic link dir. Will register additional file watcher.");
                 RegisterFileWatcher(path);


### PR DESCRIPTION
I'm not entirely sure what the intention of `TryRegisterFileWatcherForSymbolicLinkDir` is

I think it should run even if IncludeSubDirectories is false as long as `IsSymbolicLinkDirectory(path)` is true?

But this PR reverts to the previous behavior which should satisfy the test, I'm just not sure if this behavior is intentional or not